### PR TITLE
Support syncmode option

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = {
             f.datadir = options.symlink;
         }
         this.datadir = f.datadir;
+        this.syncmode = f.syncmode;
         this.flags = [];
         var rpc = false;
         var rpcport = false;


### PR DESCRIPTION
Newer versions of geth have deprecated --fast and --light in favor of --syncmode "fast" or --syncmode "light". It was necessary to add direct support for this option to geth.js.